### PR TITLE
Add Keycloak authentication client configuration

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -71,6 +71,23 @@ if options.auth == "azuread":
 else:
     azuread_app = None
 
+if options.auth == "keycloak":
+    try:
+        from keycloak import KeycloakOpenID
+
+        keycloak_client = KeycloakOpenID(
+            server_url=options.keycloak_server,
+            realm_name=options.keycloak_realm,
+            client_id=options.keycloak_client_id,
+            client_secret_key=options.keycloak_client_secret,
+            redirect_uri=options.keycloak_redirect_url,
+        )
+    except Exception as error:
+        logging.error("Keycloak client init failed: %s", error)
+        keycloak_client = None
+else:
+    keycloak_client = None
+
 ### Setup the database session
 engine = create_engine(str(db_connection), pool_pre_ping=True)
 session_maker = sessionmaker(bind=engine)

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -426,7 +426,7 @@ define(
     "auth",
     default="db",
     group="application",
-    help="The authentication mechanism, db (default) or Azure AD",
+    help="The authentication mechanism, db (default), Azure AD, or Keycloak",
 )
 
 define(
@@ -525,6 +525,17 @@ define("client_id", default="", group="azuread")
 define("tenant_id", default="common", group="azuread")
 define("client_secret", default="", group="azuread")
 define("redirect_url", default="http://localhost:8888/oidc", group="azuread")
+
+# Keycloak
+define("keycloak_server", default="", group="keycloak")
+define("keycloak_realm", default="", group="keycloak")
+define("keycloak_client_id", default="", group="keycloak")
+define("keycloak_client_secret", default="", group="keycloak")
+define(
+    "keycloak_redirect_url",
+    default="http://localhost:8888/oidc",
+    group="keycloak",
+)
 
 # ReCAPTCHA
 define(


### PR DESCRIPTION
## Summary
- extend auth option help to mention Keycloak
- add Keycloak configuration options
- initialize Keycloak OpenID client when enabled

## Testing
- `pytest`
- ⚠️ `flake8 rootthebox.py models/__init__.py` *(command not found and package install failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5545848408320a9c57cf2cae8dae4