### PR TITLE
Support Keycloak login flow

### DIFF
--- a/handlers/PublicHandlers.py
+++ b/handlers/PublicHandlers.py
@@ -229,6 +229,23 @@ class LoginHandler(BaseHandler):
                 code_flow = self.build_auth_code_flow()
                 self.memcached.add(code_flow["state"], code_flow)
                 self.redirect(code_flow["auth_uri"])
+            elif options.auth == "keycloak":
+                state = urlsafe_b64encode(urandom(24)).decode("utf-8")
+                nonce = urlsafe_b64encode(urandom(24)).decode("utf-8")
+                params = {
+                    "client_id": options.keycloak_client_id,
+                    "response_type": "code",
+                    "scope": "openid email profile",
+                    "redirect_uri": options.redirect_url,
+                    "state": state,
+                    "nonce": nonce,
+                }
+                auth_url = (
+                    options.keycloak_authorization_endpoint + "?" + urlencode(params)
+                )
+                code_flow = {"state": state, "nonce": nonce, "auth_uri": auth_url}
+                self.memcached.add(state, code_flow)
+                self.redirect(auth_url)
             else:
                 self.render("public/login.html", info=None, errors=None)
 

--- a/templates/public/login.html
+++ b/templates/public/login.html
@@ -9,6 +9,7 @@
 
 {% block content %}
 <div class="container">
+    {% if options.auth != "keycloak" %}
     <form class="form-signin" action="/login" method="post">
         <h3 class="form-signin-heading">
             <i class="fa fa-lock"></i>
@@ -47,6 +48,7 @@
         <a href="/reset" style="float: right;">{{ _('Forgot Password') }}</a>
         {% end %}
     </form>
+    {% end %}
 </div> <!-- /container -->
 <br />
 {% end %}


### PR DESCRIPTION
## Summary
- Add Keycloak branch to login handler to initiate OIDC flow and store state in memcached
- Hide login form when Keycloak authentication is enabled

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5546aabd48320a507f14abcb85ea1